### PR TITLE
Cabcookie/issue6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.36](https://github.com/cabcookie/potsdam-bot/compare/v0.1.35...v0.1.36) (2022-02-22)
+
+
+### Features
+
+* **deploy:** Re-active the CI/CD pipeline again ([239bbf7](https://github.com/cabcookie/potsdam-bot/commit/239bbf7f8350f0d96dba0ee56c75d0c4528d7ff8)), closes [#6](https://github.com/cabcookie/potsdam-bot/issues/6)
+
 ### [0.1.35](https://github.com/cabcookie/potsdam-bot/compare/v0.1.34...v0.1.35) (2022-02-22)
 
 

--- a/infra/bin/potsdam-bot.ts
+++ b/infra/bin/potsdam-bot.ts
@@ -1,25 +1,11 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
-// import { PotsdamBotStack } from '../lib/potsdam-bot-stack';
-import { LambdaCrawlerStack } from '../lib/lambda-crawler-stack';
+import { PotsdamBotStack } from '../lib/potsdam-bot-stack';
 
 const app = new App();
 
-/**
- * TODO: Add a pipeline according to this article: https://docs.aws.amazon.com/cdk/v2/guide/cdk_pipeline.html
- * include testing to deploy the app from a staging environment to a production environment
- * actually the pipeline should react to changes on the branch 'dev'
- * and push changes to the branch 'main' whenever everything is okay, and whenever it is not,
- * it should create an issue including the CloudWatch logs trail.
- * A push to 'main' should then trigger a deployment to the production system. 
- * 
- * Maybe this article is helpful as well: https://taimos.de/blog/deploying-your-cdk-app-to-different-stages-and-environments
- * or this one: https://sbstjn.com/blog/deploy-react-cra-with-cdk-codepipeline-and-codebuild/
- */
-
-new LambdaCrawlerStack(app, 'PBotCrawlerStack', {
-// new PotsdamBotStack(app, 'PotsdamBotContainerStack', {
+new PotsdamBotStack(app, 'PotsdamBotContainerStack', {
   stackName: 'potsdam-bot',
   description: 'This creates a bot which crawls for available slots at the Potsdam Bürgerservice, books one according to the preference of the citizen and informs the person about the success.',
   env: {

--- a/infra/lib/pbot-crawler-stage.ts
+++ b/infra/lib/pbot-crawler-stage.ts
@@ -1,32 +1,14 @@
-import { Stack, StackProps, Stage } from "aws-cdk-lib";
-import { Function, InlineCode, Runtime } from "aws-cdk-lib/aws-lambda";
+import { StackProps, Stage } from "aws-cdk-lib";
 import { Construct } from "constructs";
-// import { LambdaCrawlerStack } from "./lambda-crawler-stack";
-
-class TempLambdaStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
-    super(scope, id, props);
-
-    new Function(this, 'TempLambda', {
-      functionName: 'tempLambda',
-      code: new InlineCode('exports.handler = _ => "Hello CDK";'),
-      runtime: Runtime.NODEJS_14_X,
-      handler: 'index.handler',
-    });
-  }
-}
+import { LambdaCrawlerStack } from "./lambda-crawler-stack";
 
 export class PBotCrawlerStage extends Stage {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    new TempLambdaStack(this, 'TempLambdaStack', {
-      stackName: 'TempLambdaStack',
+    new LambdaCrawlerStack(this, 'PBotCrawlerStack', {
+      stackName: 'PBotCrawlerStack',
+      description: 'Creating the Lambda that crawls the desired URL.'
     });
-
-    // new LambdaCrawlerStack(this, 'PBotCrawlerStack', {
-    //   stackName: 'PBotCrawlerStack',
-    //   description: 'Creating the Lambda that crawls the desired URL.'
-    // });
   }
 }

--- a/infra/lib/potsdam-bot-stack.ts
+++ b/infra/lib/potsdam-bot-stack.ts
@@ -20,9 +20,9 @@ export class PotsdamBotStack extends Stack {
       }),
     });
 
-    // pipeline.addStage(new PBotCrawlerStage(this, 'PBotCrawlerStage', {
-    //   stackName: 'PBotCrawlerStage',
-    //   description: 'Creating the Lambda function which crawls the desired URL.',
-    // }));
+    pipeline.addStage(new PBotCrawlerStage(this, 'PBotCrawlerStage', {
+      stackName: 'PBotCrawlerStage',
+      description: 'Creating the Lambda function which crawls the desired URL.',
+    }));
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "potsdam-bot",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "potsdam-bot",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potsdam-bot",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "This bot exist to organize a meeting in the Bürgerbüro. It is hard to get a slot, so this bot should register one automatically if one is available. It will inform you via SMS if a slot it booked.",
   "bin": {
     "potsdam-bot": "infra/bin/potsdam-bot.js"


### PR DESCRIPTION
Re-active the CI/CD pipeline again, fixes #6
The AWS Account was not allowed to prepare two builds as once. Therefore we needed to build the docker image for the Lambda locally. Now, the AWS Account should be able to handle two parallel builds. Will reactivate the pipeline again.